### PR TITLE
Adds Request IDs Middleware to Express API Project

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-hilary",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Yeoman generator for projects that use hilary IoC (DI)",
   "keywords": [
     "yeoman-generator",

--- a/projects/expressApiProject.js
+++ b/projects/expressApiProject.js
@@ -43,6 +43,10 @@ function Files (choices) {
         // api
         { src: '/api/index.js'},
         { src: '/api/README.md', template: true },
+        // common
+        { src: '/common/index.js'},
+        { src: '/common/idFactory.js'},
+        { src: '/common/makeReadOnly.js'},
         // build-tasks
         { src: '/build-tasks/help.js'},
         { src: '/build-tasks/lint.js'},
@@ -70,6 +74,7 @@ function Files (choices) {
         { src: '/express/CorsHandler.js' },
         { src: '/express/express-errors-404.js' },
         { src: '/express/express-errors-500.js' },
+        { src: '/express/express-request-ids.js' },
         { src: '/express/express-startup.js' },
         { src: '/express/hbsBlocks.js' },
         { src: '/express/VersionHandler.js' },
@@ -92,11 +97,15 @@ function Files (choices) {
 
     if (choices.mocha) {
         files.push({ src: '/build-tasks/test.js' });
+        files.push({ src: '/tests/common/fixture.js' });
+        files.push({ src: '/tests/common/makeReadOnly-spec.js' });
         files.push({ src: '/tests/composition-helpers/register-bdd.js' });
+        files.push({ src: '/tests/composition-helpers/register-log-memory.js' });
         files.push({ src: '/tests/composition-helpers/register-log-suppressor.js' });
         files.push({ src: '/tests/error-handling/fixture.js' });
         files.push({ src: '/tests/error-handling/ExceptionHandler-spec.js' });
         files.push({ src: '/tests/express/fixture.js' });
+        files.push({ src: '/tests/express/express-request-ids-spec.js' });
         files.push({ src: '/tests/express/mockEnvironment.js' });
         files.push({ src: '/tests/express/VersionHandler-spec.js' });
     }

--- a/templates/projects/express-api/common/idFactory.js
+++ b/templates/projects/express-api/common/idFactory.js
@@ -7,21 +7,23 @@ module.exports.factory = function (ObjectID, exceptions) {
 
     var idFactory = {
         /*
-        // Generates a new bson ObjectID, or converts a string into one
-        // @param uid (optional)(string): when a uid is supplied, it will attempt to convert that string into a MongoUid
-        // @returns (MongoUid): the mongo unique identifier
+        // Generates a new BSON ObjectID, or converts a string into one
+        // @param uid (optional)(string): when a uid is supplied, it will
+        //      attempt to convert that string into a BSON ObjectID
+        // @returns (BSON ObjectID): the unique identifier
         */
         makeObjectId: makeObjectId,
         /*
         // Generates a new unqiue identifer
-        // @param length (optional)(int)(default = 8): when supplied the generated uid will be the length desired
+        // @param length (optional)(int)(default = 8): when supplied the
+        //      generated uid will be the length desired
         // @returns (string): the unique identifier
         */
         makeUid: makeUid,
         /*
-        // Generates a 32 character Globally Unique Identifier
+        // Generates a 32 character Universally Unique Identifier
         */
-        makeGuid: makeGuid
+        makeUuid: makeUuid
     };
 
     function createRandomString (templateString) {
@@ -52,7 +54,7 @@ module.exports.factory = function (ObjectID, exceptions) {
         return createRandomString(template);
     }
 
-    function makeGuid () {
+    function makeUuid () {
         return createRandomString('xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx');
     }
 

--- a/templates/projects/express-api/common/idFactory.js
+++ b/templates/projects/express-api/common/idFactory.js
@@ -1,0 +1,60 @@
+/*jshint bitwise: false*/
+module.exports.name = 'common-idFactory';
+module.exports.singleton = true;
+module.exports.dependencies = ['ObjectID', 'exceptions'];
+module.exports.factory = function (ObjectID, exceptions) {
+  'use strict';
+
+    var idFactory = {
+        /*
+        // Generates a new bson ObjectID, or converts a string into one
+        // @param uid (optional)(string): when a uid is supplied, it will attempt to convert that string into a MongoUid
+        // @returns (MongoUid): the mongo unique identifier
+        */
+        makeObjectId: makeObjectId,
+        /*
+        // Generates a new unqiue identifer
+        // @param length (optional)(int)(default = 8): when supplied the generated uid will be the length desired
+        // @returns (string): the unique identifier
+        */
+        makeUid: makeUid,
+        /*
+        // Generates a 32 character Globally Unique Identifier
+        */
+        makeGuid: makeGuid
+    };
+
+    function createRandomString (templateString) {
+        return templateString.replace(/[xy]/g, function (c) {
+            var r = Math.random() * 16 | 0,
+                v = c === 'x' ? r : r & 3 | 8;
+            return v.toString(16);
+        });
+    }
+
+    function makeObjectId (uid) {
+        if (!uid) {
+            var id = new ObjectID();
+            return id;
+        } else if (ObjectID.isValid(uid)) {
+            return new ObjectID(uid);
+        } else {
+            return exceptions.throw(new Error('Invalid ObjectID: ' + uid.toString()));
+        }
+    }
+
+    function makeUid (length) {
+        var template;
+
+        length = (typeof length === 'number' && length > 0 && length) || 8;
+        template = new Array(length + 1).join('x');
+
+        return createRandomString(template);
+    }
+
+    function makeGuid () {
+        return createRandomString('xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx');
+    }
+
+    return idFactory;
+};

--- a/templates/projects/express-api/common/index.js
+++ b/templates/projects/express-api/common/index.js
@@ -1,0 +1,4 @@
+module.exports = [
+    require('./idFactory.js'),
+    require('./makeReadOnly.js')
+];

--- a/templates/projects/express-api/common/makeReadOnly.js
+++ b/templates/projects/express-api/common/makeReadOnly.js
@@ -1,0 +1,79 @@
+module.exports.name = 'common-makeReadOnly';
+module.exports.singleton = true;
+module.exports.dependencies = ['polyn::is', 'logger'];
+module.exports.factory = function (is, logger) {
+    'use strict';
+
+    var mutatingArrayFunctions = [
+            'setPrototypeOf', 'push', 'pop', 'sort', 'splice', 'shift',
+            'unshift', 'reverse'
+        ],
+        mutatingDateFunctions = [
+            'setPrototypeOf', 'setDate', 'setFullYear', 'setHours',
+            'setMilliseconds', 'setMinutes', 'setMonth', 'setSeconds',
+            'setTime', 'setUTCDate', 'setUTCFullYear', 'setUTCHours',
+            'setUTCMilliseconds', 'setUTCMinutes', 'setUTCMonth',
+            'setUTCSeconds', 'setYear'
+        ],
+        DEFAULT_ERROR_TEMPLATE = 'the {{name}} property is read-only';
+
+    /*
+    // Example 1 (basic usage):
+    // var requestIds = {};
+    // makeReadOnly('clientId', clientId).on(requestIds);
+    //
+    // Example 2 (with error message):
+    // var requestIds = {};
+    // makeReadOnly('clientId', clientId)
+    //      .withSetMessage('clientId on requestIds is immutable')
+    //      .on(requestIds);
+    */
+    function makeReadOnly(name, val) {
+        var defaultErrorMessage = DEFAULT_ERROR_TEMPLATE
+                .replace(/{{name}}/, name),
+            message,
+            self = {
+                withSetMessage: withSetMessage,
+                on: on
+            };
+
+        if (is.array(val)) {
+            mutatingArrayFunctions.forEach(function (func) {
+                val[func] = makeSetter(message);
+            });
+        } else if (is.datetime(val)) {
+            mutatingDateFunctions.forEach(function (func) {
+                val[func] = makeSetter(message);
+            });
+        }
+
+        function withSetMessage (errorMessage) {
+            if (is.string(errorMessage)) {
+                message = errorMessage;
+            }
+
+            return {
+                on: on
+            };
+        }
+
+        function on (obj) {
+            Object.defineProperty (obj, name, {
+                get: function () { return val; },
+                set: makeSetter(message || defaultErrorMessage),
+                enumerable: true,
+                configurable: false
+            });
+        }
+
+        return self;
+    }
+
+    function makeSetter (message) {
+        return function () {
+            logger.error(new Error(message));
+        };
+    }
+
+    return makeReadOnly;
+};

--- a/templates/projects/express-api/composition.js
+++ b/templates/projects/express-api/composition.js
@@ -3,13 +3,17 @@
 module.exports.init = init;
 
 var Hilary = require('hilary'),
+    polyn = require('polyn'),
     async = require('async'),
     express = require('express'),
     nconf = require('nconf'),
+    ObjectID = require('bson-objectid'),
+    // directories
+    api = require('./api'),
+    common = require('./common'),
     environment = require('./environment.js'),
     env = environment.factory(nconf),
     errorHandling = require('./error-handling'),
-    api = require('./api'),
     expressConfig = require('./express'),
     scopeId = env.get('projectName');
     // log and various other function defined at bottom
@@ -41,16 +45,16 @@ function init() {
             // perform composition tasks (register modules here)
             log('composing application modules');
 
+            scope.register({ name: 'appDir', singleton: true, factory: __dirname });
+            scope.register({ name: 'ObjectID', singletong: true, factory: ObjectID, dependencies: [] });
+            scope.register({ name: 'polyn::Immutable', singleton: true, factory: polyn.Immutable, dependencies: [] });
+            scope.register({ name: 'polyn::is', singleton: true, factory: polyn.is, dependencies: [] });
+
             scope.register({ name: 'environment', factory: function () { return env; }});
+            scope.autoRegister(api);
+            scope.autoRegister(common);
             scope.autoRegister(errorHandling);
             scope.autoRegister(expressConfig);
-            scope.autoRegister(api);
-
-            scope.register({
-                name: 'appDir',
-                singleton: true,
-                factory: __dirname
-            });
 
             composeExpress(scope);
         },

--- a/templates/projects/express-api/environment/environment.json
+++ b/templates/projects/express-api/environment/environment.json
@@ -10,8 +10,8 @@
         },
         "allowCredentials": true,
         "allowMethods": ["GET", "POST", "PATCH", "PUT", "DELETE", "OPTIONS", "HEAD"],
-        "allowHeaders": ["Authorization", "Accepts", "Content-Type", "If-Match", "If-Modified-Since", "If-None-Match", "If-Unmodified-Since", "Range", "X-Requested-With"],
-        "exposeHeaders": ["Content-Length", "Date", "ETag", "Expires", "Last-Modified", "X-Powered-By"],
+        "allowHeaders": ["Authorization", "Accepts", "Content-Type", "If-Match", "If-Modified-Since", "If-None-Match", "If-Unmodified-Since", "Range", "X-Requested-With", "X-Request-ID"],
+        "exposeHeaders": ["Content-Length", "Date", "ETag", "Expires", "Last-Modified", "X-Powered-By", "X-Request-ID", "X-<%= projectName %>-Media-Type"],
         "cacheDuration": "120",
         "denialMessage": { "status": 403, "message": "CORS Error: your origin, {origin}, is not whitelisted." }
     },

--- a/templates/projects/express-api/express/express-request-ids.js
+++ b/templates/projects/express-api/express/express-request-ids.js
@@ -1,0 +1,39 @@
+module.exports.name = 'express-request-ids';
+module.exports.singleton = true;
+module.exports.dependencies = ['ObjectID', 'common-makeReadOnly'];
+module.exports.factory = function (ObjectID, makeReadOnly) {
+    'use strict';
+
+    var header = 'X-Request-ID';
+
+    return function (req, res, next) {
+            // the server request ID is guaranteed to be unique per request
+        var serverId = makeRequestId(),
+            // the client request ID _can_ be defined by the client.
+            // this is NOT guaranteed to be unique per request, if the client
+            // actually sets it. The server request ID is used if the client
+            // does not set it.
+            clientId = makeRequestId(req.get(header), serverId),
+            requestIds = {};
+
+        makeReadOnly('clientId', clientId).on(requestIds);
+        makeReadOnly('serverId', serverId).on(requestIds);
+
+        // puts read-only request IDs on res.locals
+        makeReadOnly('requestIds', requestIds).on(res.locals);
+
+        // puts the client request ID in the response headers, so the client
+        // can use it for continuity checks, logging, support calls, etc.
+        res.setHeader(header, res.locals.requestIds.clientId.toString());
+
+        next();
+    };
+
+    function makeRequestId (uid, defaultId) {
+        if (!uid || !ObjectID.isValid(uid)) {
+            return defaultId ? defaultId : new ObjectID();
+        } else {
+            return new ObjectID(uid);
+        }
+    }
+};

--- a/templates/projects/express-api/express/express-request-ids.js
+++ b/templates/projects/express-api/express/express-request-ids.js
@@ -8,7 +8,7 @@ module.exports.factory = function (ObjectID, makeReadOnly) {
 
     return function (req, res, next) {
             // the server request ID is guaranteed to be unique per request
-        var serverId = makeRequestId(),
+        var serverId = new ObjectID(),
             // the client request ID _can_ be defined by the client.
             // this is NOT guaranteed to be unique per request, if the client
             // actually sets it. The server request ID is used if the client
@@ -29,11 +29,16 @@ module.exports.factory = function (ObjectID, makeReadOnly) {
         next();
     };
 
-    function makeRequestId (uid, defaultId) {
-        if (!uid || !ObjectID.isValid(uid)) {
-            return defaultId ? defaultId : new ObjectID();
-        } else {
+    function makeRequestId (uid, serverId) {
+        if (!uid) {
+            // the client did not present a request ID, use the serverId
+            return serverId;
+        } else if (ObjectID.isValid(uid)) {
+            // the client presented a BSON ObjectID as the request ID
             return new ObjectID(uid);
+        } else {
+            // the client presented an unknown type of request ID
+            return uid;
         }
     }
 };

--- a/templates/projects/express-api/express/express-startup.js
+++ b/templates/projects/express-api/express/express-startup.js
@@ -13,9 +13,10 @@ module.exports.dependencies = [
     'defaultCorsHandler',
     'VersionHandler',
     'express-errors-404',
-    'express-errors-500'
+    'express-errors-500',
+    'express-request-ids'
 ];
-module.exports.factory = function (app, path, appDir, bodyParser, favicon, serveStatic, hbs, extendHbs, helmet, hpp, corsHandler, VersionHandler, on404, on500) {
+module.exports.factory = function (app, path, appDir, bodyParser, favicon, serveStatic, hbs, extendHbs, helmet, hpp, corsHandler, VersionHandler, on404, on500, requestIds) {
     'use strict';
 
     var init,
@@ -53,6 +54,7 @@ module.exports.factory = function (app, path, appDir, bodyParser, favicon, serve
         app.set('view engine', 'hbs');
         extendHbs(hbs);
 
+        app.use(requestIds);
         app.use(corsHandler);
         app.use(helmet.hsts({
             maxAge: 10886400000,        // Must be at least 18 weeks to be approved by Google

--- a/templates/projects/express-api/express/index.js
+++ b/templates/projects/express-api/express/index.js
@@ -3,6 +3,7 @@ module.exports = [
     require('./defaultCorsHandler.js'),
     require('./express-errors-404.js'),
     require('./express-errors-500.js'),
+    require('./express-request-ids.js'),
     require('./express-startup.js'),
     require('./hbsBlocks.js'),
     require('./versionHandler.js'),

--- a/templates/projects/express-api/package.js
+++ b/templates/projects/express-api/package.js
@@ -10,6 +10,7 @@ module.exports = {
     "dependencies": {
         "async": "^2.1.4",
         "body-parser": "^1.15.2",
+        "bson-objectid": "^1.1.5",
         "express": "^4.14.0",
         "hbs": "^4.0.1",
         "helmet": "^3.4.0",
@@ -18,7 +19,7 @@ module.exports = {
         "hpp": "^0.2.1",
         "marked": "^0.3.6",
         "nconf": "^0.8.4",
-        "polyn": "^1.6.1",
+        "polyn": "^1.6.*",
         "serve-favicon": "^2.3.2",
         "serve-static": "^1.11.1"
     },

--- a/templates/projects/express-api/tests/common/fixture.js
+++ b/templates/projects/express-api/tests/common/fixture.js
@@ -1,0 +1,46 @@
+'use strict';
+
+var Hilary = require('hilary'),
+    polyn = require('polyn'),
+    ObjectID = require('bson-objectid'),
+    registerBdd = require(relativeToTest('composition-helpers/register-bdd.js')),
+    registerLogMemory = require(relativeToTest('composition-helpers/register-log-memory.js')),
+    makeReadOnly = require(relativeToRoot('common/makeReadOnly.js')),
+    makeReadOnlySpec = require('./makeReadOnly-spec.js');
+
+function relativeToTest(path) { return '../' + path; }
+function relativeToRoot(path) { return '../../' + path; }
+
+new Hilary().Bootstrapper({
+    composeLifecycle: function (err, scope, pipeline) {
+        pipeline.register.on.error(function (err) {
+            console.log(err);
+        });
+    },
+    composeModules: function (err, scope) {
+        registerBdd(scope);
+        registerLogMemory(scope);
+
+        scope.register({ name: 'ObjectID', singleton: true, dependencies: [], factory: ObjectID });
+        scope.register({ name: 'polyn::is', singleton: true, dependencies: [], factory: polyn.is });
+
+        scope.register(makeReadOnly);
+        scope.register(makeReadOnlySpec);
+
+        scope.register({
+            name: 'fixture',
+            dependencies: ['describe'],
+            factory: function (describe) {
+
+                describe('common', function () {
+                    scope.resolve('makeReadOnly-spec');
+                });
+
+                return true;
+            }
+        });
+    },
+    onComposed: function (err, scope) {
+        scope.resolve('fixture');
+    }
+});

--- a/templates/projects/express-api/tests/common/makeReadOnly-spec.js
+++ b/templates/projects/express-api/tests/common/makeReadOnly-spec.js
@@ -1,0 +1,52 @@
+module.exports.name = 'makeReadOnly-spec';
+module.exports.dependencies = ['common-makeReadOnly', 'logger', 'ObjectID', 'describe', 'describe', 'describe', 'it', 'expect'];
+module.exports.factory = function (makeReadOnly, logger, ObjectID, describe, when, and, it, expect) {
+    'use strict';
+
+    describe('makeReadOnly', function () {
+        when('when makeImmutable is followed by on', function () {
+
+            it('it should set a property on the given object', function () {
+                var given = {};
+                makeReadOnly('foo', 42).on(given);
+                expect(given.foo).to.equal(42);
+            });
+
+            it('the given property should be read-only', function () {
+                var given = {};
+                makeReadOnly('foo', 42).on(given);
+                given.foo = 44;
+                expect(given.foo).to.equal(42);
+            });
+
+            and('and the object is not defined', function () {
+                it('it should throw', function () {
+                    try {
+                        makeReadOnly('foo', 42).on(null);
+                        expect('if we got here the test failed').to.equal(false);
+                    } catch (e) {
+                        expect(e).to.not.equal(undefined);
+                    }
+                });
+            });
+        }); // /when
+
+        when('when makeImmutable is followed by withSetMessage', function () {
+            it('it should use that error message when code tries to set the read-only property', function () {
+                var given = {},
+                    expected = new ObjectID().toString();
+
+                makeReadOnly('foo', 42)
+                    .withSetMessage(expected)
+                    .on(given);
+
+                given.foo = 44;
+
+                expect(logger.findByMessage(expected).length).to.equal(1);
+            });
+        }); // /when
+
+    }); // /describe
+
+    return true;
+};

--- a/templates/projects/express-api/tests/composition-helpers/register-log-memory.js
+++ b/templates/projects/express-api/tests/composition-helpers/register-log-memory.js
@@ -1,0 +1,46 @@
+module.exports = register;
+
+var logs = [],
+    log = function (arg) {
+        'use strict';
+
+        if (typeof arg === 'string') {
+            // supress output and add to array instead
+            logs.push({ message: arg, err: null });
+        } else if (arg && arg.message) {
+            // supress output and add to array instead
+            logs.push({ message: arg.message, err: arg });
+        } else {
+            console.log(this.args);
+        }
+    };
+
+function register (scope) {
+    'use strict';
+
+    scope.register({ name: 'logger', singleton: true, factory: {
+            debug: log,
+            trace: log,
+            info: log,
+            warn: log,
+            error: log,
+            fatal: log,
+            getLogs: getLogs,
+            findByMessage: findByMessage
+        }
+    });
+}
+
+function getLogs () {
+    'use strict';
+
+    return logs;
+}
+
+function findByMessage (message) {
+    'use strict';
+
+    return logs.filter(function (log) {
+        return log.message === message;
+    });
+}

--- a/templates/projects/express-api/tests/express/express-request-ids-spec.js
+++ b/templates/projects/express-api/tests/express/express-request-ids-spec.js
@@ -5,7 +5,7 @@ module.exports.factory = function (sut, ObjectID, describe, when, and, it, expec
 
     describe('express-request-ids', function () {
         when('when the middleware is executed', function () {
-            and('and a valid X-Request-ID header is present', function () {
+            and('and a BSON ObjectID X-Request-ID header is present', function () {
                 it('it should set res.locals.requestIds.clientId to the given X-Request-ID', function (done) {
                     var expected = new ObjectID().toString(),
                         req = makeMockReq({ 'X-Request-ID': expected }),
@@ -43,7 +43,7 @@ module.exports.factory = function (sut, ObjectID, describe, when, and, it, expec
                 });
             });
 
-            and('and an INVALID X-Request-ID header is present', function () {
+            and('and an UNKNOWN type of X-Request-ID header is present', function () {
                 it('it should set res.locals.requestIds.serverId to a DIFFERENT id', function (done) {
                     var header = '12345',
                         req = makeMockReq({ 'X-Request-ID': header }),
@@ -51,32 +51,33 @@ module.exports.factory = function (sut, ObjectID, describe, when, and, it, expec
 
                     sut(req, res, function () {
                         expect(typeof res.locals.requestIds).to.equal('object');
-                        expect(res.locals.requestIds.clientId.toString()).to.not.equal(header);
-                        expect(ObjectID.isValid(res.locals.requestIds.clientId)).to.equal(true);
+                        expect(res.locals.requestIds.serverId.toString()).to.not.equal(header);
                         done();
                     });
                 });
 
-                it('it should set res.locals.requestIds.clientId to the serverId', function (done) {
-                    var req = makeMockReq({ 'X-Request-ID': '12345' }),
+                it('it should set res.locals.requestIds.clientId to the clientId', function (done) {
+                    var header = '12345',
+                        req = makeMockReq({ 'X-Request-ID': header }),
                         res = makeMockRes();
 
                     sut(req, res, function () {
                         expect(typeof res.locals.requestIds).to.equal('object');
-                        expect(res.locals.requestIds.clientId.toString())
-                            .to.equal(res.locals.requestIds.serverId.toString());
+                        expect(res.locals.requestIds.clientId)
+                            .to.equal(header);
                         done();
                     });
                 });
 
-                it('it should set the response header to the serverId', function (done) {
-                    var req = makeMockReq({ 'X-Request-ID': '12345' }),
+                it('it should set the response header to the clientId', function (done) {
+                    var header = '12345',
+                        req = makeMockReq({ 'X-Request-ID': header }),
                         res = makeMockRes();
 
                     sut(req, res, function () {
                         expect(typeof res.locals.requestIds).to.equal('object');
                         expect(res._headers['X-Request-ID'])
-                            .to.equal(res.locals.requestIds.serverId.toString());
+                            .to.equal(res.locals.requestIds.clientId);
                         done();
                     });
                 });

--- a/templates/projects/express-api/tests/express/express-request-ids-spec.js
+++ b/templates/projects/express-api/tests/express/express-request-ids-spec.js
@@ -1,0 +1,149 @@
+module.exports.name = 'express-request-ids-spec';
+module.exports.dependencies = ['express-request-ids', 'ObjectID', 'describe', 'describe', 'describe', 'it', 'expect'];
+module.exports.factory = function (sut, ObjectID, describe, when, and, it, expect) {
+    'use strict';
+
+    describe('express-request-ids', function () {
+        when('when the middleware is executed', function () {
+            and('and a valid X-Request-ID header is present', function () {
+                it('it should set res.locals.requestIds.clientId to the given X-Request-ID', function (done) {
+                    var expected = new ObjectID().toString(),
+                        req = makeMockReq({ 'X-Request-ID': expected }),
+                        res = makeMockRes();
+
+                    sut(req, res, function () {
+                        expect(typeof res.locals.requestIds).to.equal('object');
+                        expect(res.locals.requestIds.clientId.toString()).to.equal(expected);
+                        done();
+                    });
+                });
+
+                it('it should set res.locals.requestIds.serverId to a DIFFERENT id', function (done) {
+                    var clientId = new ObjectID().toString(),
+                        req = makeMockReq({ 'X-Request-ID': clientId }),
+                        res = makeMockRes();
+
+                    sut(req, res, function () {
+                        expect(typeof res.locals.requestIds).to.equal('object');
+                        expect(res.locals.requestIds.serverId.toString()).to.not.equal(clientId);
+                        done();
+                    });
+                });
+
+                it('it should set the response header to the given X-Request-ID', function (done) {
+                    var expected = new ObjectID().toString(),
+                        req = makeMockReq({ 'X-Request-ID': expected }),
+                        res = makeMockRes();
+
+                    sut(req, res, function () {
+                        expect(typeof res.locals.requestIds).to.equal('object');
+                        expect(res._headers['X-Request-ID']).to.equal(expected);
+                        done();
+                    });
+                });
+            });
+
+            and('and an INVALID X-Request-ID header is present', function () {
+                it('it should set res.locals.requestIds.serverId to a DIFFERENT id', function (done) {
+                    var header = '12345',
+                        req = makeMockReq({ 'X-Request-ID': header }),
+                        res = makeMockRes();
+
+                    sut(req, res, function () {
+                        expect(typeof res.locals.requestIds).to.equal('object');
+                        expect(res.locals.requestIds.clientId.toString()).to.not.equal(header);
+                        expect(ObjectID.isValid(res.locals.requestIds.clientId)).to.equal(true);
+                        done();
+                    });
+                });
+
+                it('it should set res.locals.requestIds.clientId to the serverId', function (done) {
+                    var req = makeMockReq({ 'X-Request-ID': '12345' }),
+                        res = makeMockRes();
+
+                    sut(req, res, function () {
+                        expect(typeof res.locals.requestIds).to.equal('object');
+                        expect(res.locals.requestIds.clientId.toString())
+                            .to.equal(res.locals.requestIds.serverId.toString());
+                        done();
+                    });
+                });
+
+                it('it should set the response header to the serverId', function (done) {
+                    var req = makeMockReq({ 'X-Request-ID': '12345' }),
+                        res = makeMockRes();
+
+                    sut(req, res, function () {
+                        expect(typeof res.locals.requestIds).to.equal('object');
+                        expect(res._headers['X-Request-ID'])
+                            .to.equal(res.locals.requestIds.serverId.toString());
+                        done();
+                    });
+                });
+            });
+
+            and('and an X-Request-ID header is NOT present', function () {
+                it('it should set res.locals.requestIds.serverId', function (done) {
+                    var req = makeMockReq(),
+                        res = makeMockRes();
+
+                    sut(req, res, function () {
+                        expect(typeof res.locals.requestIds).to.equal('object');
+                        expect(ObjectID.isValid(res.locals.requestIds.serverId)).to.equal(true);
+                        done();
+                    });
+                });
+
+                it('it should set res.locals.requestIds.clientId to the serverId', function (done) {
+                    var req = makeMockReq(),
+                        res = makeMockRes();
+
+                    sut(req, res, function () {
+                        expect(typeof res.locals.requestIds).to.equal('object');
+                        expect(res.locals.requestIds.clientId.toString())
+                            .to.equal(res.locals.requestIds.serverId.toString());
+                        done();
+                    });
+                });
+
+                it('it should set the response header to the serverId', function (done) {
+                    var req = makeMockReq(),
+                        res = makeMockRes();
+
+                    sut(req, res, function () {
+                        expect(typeof res.locals.requestIds).to.equal('object');
+                        expect(res._headers['X-Request-ID'])
+                            .to.equal(res.locals.requestIds.serverId.toString());
+                        done();
+                    });
+                });
+            });
+        });
+    });
+
+    // NOTE: this matches the express response API, but not behavior
+    function makeMockReq (headers) {
+        headers = headers || {};
+
+        return {
+            get: function (name) {
+                return headers[name];
+            }
+        };
+    }
+
+    // NOTE: this matches the express response API, but not behavior
+    function makeMockRes () {
+        var _headers = {};
+
+        return {
+            setHeader: function (name, val) {
+                _headers[name] = val;
+            },
+            _headers: _headers,
+            locals: {}
+        };
+    }
+
+    return true;
+};

--- a/templates/projects/express-api/tests/express/fixture.js
+++ b/templates/projects/express-api/tests/express/fixture.js
@@ -1,13 +1,17 @@
 'use strict';
 
 var Hilary = require('hilary'),
+    polyn = require('polyn'),
+    ObjectID = require('bson-objectid'),
     errorHandling = require(relativeToRoot('error-handling')),
     env = require('./mockEnvironment.js'),
     express = require(relativeToRoot('express')),
     VersionHandler = require(relativeToRoot('express/VersionHandler.js')),
+    makeReadOnly = require(relativeToRoot('common/makeReadOnly.js')),
     registerBdd = require('../composition-helpers/register-bdd.js'),
     registerLogSuppressor = require('../composition-helpers/register-log-suppressor.js'),
-    VersionHandleSpec = require('./VersionHandler-spec.js');
+    expressRequestIdsSpec = require('./express-request-ids-spec.js'),
+    VersionHandlerSpec = require('./VersionHandler-spec.js');
 
 function relativeToRoot(path) { return '../../' + path; }
 
@@ -20,12 +24,18 @@ new Hilary().Bootstrapper({
     composeModules: function (err, scope) {
         scope.autoRegister(errorHandling);
         scope.autoRegister(express);
-        scope.register({name: 'VersionHandlerFactory', factory: function () { return VersionHandler.factory; }});
         scope.register(env);
+        scope.register(makeReadOnly);
+        scope.register({name: 'VersionHandlerFactory', factory: function () { return VersionHandler.factory; }});
+
+        scope.register({ name: 'ObjectID', singleton: true, dependencies: [], factory: ObjectID });
+        scope.register({ name: 'polyn::is', singleton: true, dependencies: [], factory: polyn.is });
+
         registerBdd(scope);
         registerLogSuppressor(scope);
 
-        scope.register(VersionHandleSpec);
+        scope.register(expressRequestIdsSpec);
+        scope.register(VersionHandlerSpec);
 
         scope.register({
             name: 'fixture',
@@ -33,6 +43,7 @@ new Hilary().Bootstrapper({
             factory: function (describe) {
 
                 describe('express middleware,', function () {
+                    scope.register(expressRequestIdsSpec);
                     scope.resolve('VersionHandler-spec');
                 });
 

--- a/templates/projects/express-api/tests/express/fixture.js
+++ b/templates/projects/express-api/tests/express/fixture.js
@@ -43,7 +43,7 @@ new Hilary().Bootstrapper({
             factory: function (describe) {
 
                 describe('express middleware,', function () {
-                    scope.register(expressRequestIdsSpec);
+                    scope.resolve('express-request-ids-spec');
                     scope.resolve('VersionHandler-spec');
                 });
 


### PR DESCRIPTION
* Adds dependency on bson-objectid
* Adds idFactory
* Adds helper for setting read-only properties on objects
* Adds request-id middleware
    * allows clients to set an ObjectID for continuity checks
    * sets request-id response header, even when the client does not present one
    * adds separate server request ID to guarantee uniqueness per server request
* Adds simpler way to depend on polyn::Immutable and polyn::is
* Adds tests